### PR TITLE
Fix Visual noise; add tile picking, stamp capture, fix msvc build

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -46,7 +46,10 @@ jobs:
         run: echo "${{ env.QT_DIR }}\${{ env.QT_VERSION }}\msvc2019_64\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
 
       - name: Install Meson and Ninja
-        run: pip install meson ninja
+        # Pin to <1.11 to avoid mesonbuild/meson#15705: Qt tool detection
+        # regression in 1.11.0 that crashes with 'NoneType has no attribute
+        # extend' on Windows/qmake. Remove pin once upstream fixes it.
+        run: pip install 'meson<1.11' ninja
 
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1

--- a/docs/map-format.md
+++ b/docs/map-format.md
@@ -1,0 +1,144 @@
+# netPanzer Map Format
+
+A netPanzer map consists of up to three files that share a common base name:
+
+| File | Required | Content |
+|------|----------|---------|
+| `<name>.npm` | yes | Binary tile grid |
+| `<name>.opt` | no | Outpost/objective locations |
+| `<name>.spn` | no | Spawn point locations |
+
+All multi-byte integers are **little-endian**.
+
+---
+
+## .npm — Binary Tile Map
+
+### Header (1610 bytes)
+
+| Offset | Size | Type | Field |
+|--------|------|------|-------|
+| 0 | 64 | `char[]` | ID header string (e.g. `"Copyright PyroSoft Inc."`, null-padded) |
+| 64 | 2 | `uint16` | Map ID |
+| 66 | 256 | `char[]` | Map name (null-terminated, null-padded) |
+| 322 | 1024 | `char[]` | Description (null-terminated, null-padded) |
+| 1346 | 2 | `uint16` | Width in tiles |
+| 1348 | 2 | `uint16` | Height in tiles |
+| 1350 | 256 | `char[]` | Tileset filename (e.g. `"summer12mb.tls"`, null-padded) |
+| 1606 | 2 | `uint16` | Thumbnail width in pixels (0 if absent) |
+| 1608 | 2 | `uint16` | Thumbnail height in pixels (0 if absent) |
+
+### Tile Data
+
+Immediately follows the header at offset **1610**.
+
+```
+uint16  tiles[width * height]
+```
+
+Tiles are stored in row-major order (left to right, top to bottom). Each value is a zero-based index into the tileset. The tile array is `width × height × 2` bytes.
+
+### Thumbnail (optional)
+
+Immediately follows the tile data.
+
+```
+uint8  thumbnail[thumbnail_width * thumbnail_height]
+```
+
+Each byte is a palette index (same 256-colour palette as the `.tls` file). May be absent; check `thumbnail_width == 0 || thumbnail_height == 0`.
+
+### Minimum valid file size
+
+`1610 + width × height × 2` bytes (no thumbnail).
+
+---
+
+## .opt — Outpost / Objective File
+
+Plain text. One block per outpost, preceded by a count header.
+
+```
+ObjectiveCount: <N>
+
+Name: <outpost name>
+Location: <tile-x> <tile-y>
+
+Name: <outpost name>
+Location: <tile-x> <tile-y>
+```
+
+- `ObjectiveCount` gives the number of outpost blocks that follow.
+- `Name` is a human-readable label for the outpost.
+- `Location` is the outpost marker position in **tile coordinates** (not pixels).
+- Blank lines between blocks are conventional but not required.
+- If `Name` is missing for an entry, parsers should synthesise one (e.g. `Outpost#N`).
+
+### Capture pad
+
+netPanzer computes the capturable area from the outpost tile position as follows (using pixel coordinates where one tile = 32 × 32 px):
+
+```
+marker_pixel_x = tile_x * 32 + 16   // tile centre
+marker_pixel_y = tile_y * 32 + 16
+
+pad_centre_x = marker_pixel_x + 224
+pad_centre_y = marker_pixel_y + 48
+
+capture_box = pad_centre ± (48, 32) px
+```
+
+The editor draws this pad as a visual overlay when the **Place Outpost** tool is active.
+
+---
+
+## .spn — Spawn Point File
+
+Plain text. One `Location` line per spawn point, preceded by a count header.
+
+```
+SpawnCount: <N>
+Location: <tile-x> <tile-y>
+Location: <tile-x> <tile-y>
+```
+
+- `SpawnCount` gives the number of spawn points that follow.
+- `Location` is the spawn point position in **tile coordinates**.
+- Spawn points have no name field.
+
+### Quirk: no-newline format
+
+Some `.spn` files in the wild omit newlines between tokens, concatenating everything onto a single line:
+
+```
+SpawnCount: 3Location: 5 10Location: 30 40Location: 99 7
+```
+
+Parsers must normalise this by inserting a newline before each `Location:` token before parsing.
+
+---
+
+## .tls — Tileset
+
+| Offset | Size | Type | Field |
+|--------|------|------|-------|
+| 0 | 64 | `char[]` | ID header string (null-padded) |
+| 64 | 2 | `uint16` | Version (= 1) |
+| 66 | 2 | `uint16` | Tile width in pixels (= 32) |
+| 68 | 2 | `uint16` | Tile height in pixels (= 32) |
+| 70 | 2 | `uint16` | Tile count |
+| 72 | 768 | `uint8[768]` | Palette: 256 × (R, G, B) — each component 0–255 |
+| 840 | 3 × tile_count | struct | Tile headers (see below) |
+| 840 + 3×N | 1024 × tile_count | `uint8[]` | Pixel data: tile_count × 32 × 32 palette indices |
+
+### Tile header (3 bytes each)
+
+| Byte | Field |
+|------|-------|
+| 0 | Attribute flags |
+| 1 | Move value (passability) |
+| 2 | Average colour index |
+
+Pixel data for tile *i* starts at offset `840 + 3 × tile_count + i × 1024` and is 1024 bytes of palette-indexed (8-bit) pixels in row-major order.
+
+> **Note:** The editor uses the external `netp.act` Adobe Color Table palette for rendering rather than the palette embedded in the `.tls` file, to match netPanzer's runtime appearance.

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,8 @@ qt5_test_dep = dependency('qt5', modules : ['Core', 'Test'])
 moc_headers = [
   'src/mapview.h',
   'src/tilepanel.h',
+  'src/tilebrowser.h',
+  'src/stamppanel.h',
   'src/mainwindow.h',
   'src/minimap.h',
 ]
@@ -23,6 +25,8 @@ editor_sources = [
   'src/mapview.cpp',
   'src/tlsloader.cpp',
   'src/tilepanel.cpp',
+  'src/tilebrowser.cpp',
+  'src/stamppanel.cpp',
   'src/mainwindow.cpp',
   'src/minimap.cpp',
 ]

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -166,6 +166,7 @@ void MainWindow::setupMenus()
     struct ToolDef { const char* label; const char* iconText; Tool tool; QKeySequence key; };
     const ToolDef defs[] = {
         { "Tile &Paint",       "Paint",    Tool::TilePaint,       Qt::Key_T },
+        { "&Ellipse Paint",    "Ellipse",  Tool::EllipsePaint,    Qt::Key_E },
         { "Tile P&ick",        "Pick",     Tool::TilePick,        Qt::Key_I },
         { "&Rect Select",      "Rect Sel", Tool::RectSelect,      Qt::Key_R },
         { "&Stamp Paint",      "Stamp",    Tool::StampPaint,      Qt::Key_M },
@@ -622,8 +623,8 @@ void MainWindow::onSetTool(Tool t)
     // Sync tile panel: only useful when painting
     m_tilePanel->setVisible(t == Tool::TilePaint);
 
-    const char* names[] = {"Tile Paint", "Tile Pick", "Rect Select", "Stamp Paint",
-                            "Place Outpost", "Place Spawnpoint", "Select Object"};
+    const char* names[] = {"Tile Paint", "Ellipse Paint", "Tile Pick", "Rect Select",
+                            "Stamp Paint", "Place Outpost", "Place Spawnpoint", "Select Object"};
     statusBar()->showMessage(
         QString("Tool: %1").arg(names[int(t)]), 2000);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,6 +1,8 @@
 #include "mainwindow.h"
 #include "mapview.h"
 #include "tilepanel.h"
+#include "tilebrowser.h"
+#include "stamppanel.h"
 #include "minimap.h"
 #include "maploader.h"
 #include <QMenuBar>
@@ -21,6 +23,7 @@
 #include <QActionGroup>
 #include <QKeySequence>
 #include <QCloseEvent>
+#include <QTime>
 #include <cmath>
 
 // ---------------------------------------------------------------------------
@@ -37,6 +40,14 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     m_tilePanel = new TilePanel(this);
     addDockWidget(Qt::RightDockWidgetArea, m_tilePanel);
 
+    m_tileBrowser = new TileBrowser(this);
+    addDockWidget(Qt::LeftDockWidgetArea, m_tileBrowser);
+    m_tileBrowser->hide();  // hidden by default, opened from View menu
+
+    m_stampPanel = new StampPanel(this);
+    addDockWidget(Qt::LeftDockWidgetArea, m_stampPanel);
+    m_stampPanel->hide();   // hidden by default
+
     m_minimap = new Minimap(this);
     addDockWidget(Qt::RightDockWidgetArea, m_minimap);
 
@@ -50,10 +61,35 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     connect(m_view, &MapView::objectActivated,        this, &MainWindow::onObjectActivated);
     connect(m_view, &MapView::viewportChanged,        this, &MainWindow::onViewportChanged);
 
-    connect(m_tilePanel, &TilePanel::tileSelected, m_view, &MapView::setSelectedTile);
+    connect(m_tilePanel,   &TilePanel::tileSelected,   m_view, &MapView::setSelectedTile);
+    connect(m_tileBrowser, &TileBrowser::tileSelected, this, [this](int id) {
+        m_view->setSelectedTile(id);
+        m_tilePanel->setSelectedTile(id);
+        m_view->setTool(Tool::TilePaint);
+    });
+    connect(m_tileBrowser, &TileBrowser::stampCreated, this, [this](Stamp s) {
+        m_stampPanel->addStamp(std::move(s));
+        m_view->setCurrentStamp(m_stampPanel->selectedStamp());
+        m_view->setTool(Tool::StampPaint);
+        m_stampPanel->show();
+    });
     connect(m_view, &MapView::tilePicked, this, [this](int id) {
         m_view->setSelectedTile(id);
         m_tilePanel->setSelectedTile(id);
+    });
+    connect(m_stampPanel, &StampPanel::captureRequested, this, [this]() {
+        if (!m_view->hasSelection()) {
+            QMessageBox::information(this, "No selection",
+                "Use the Rect Select tool (R) to drag a region on the map first.");
+            return;
+        }
+        Stamp s = m_view->captureSelection();
+        s.name = QString("Stamp %1").arg(QTime::currentTime().toString("hh:mm:ss"));
+        m_stampPanel->addStamp(std::move(s));
+    });
+    connect(m_stampPanel, &StampPanel::stampSelected, this, [this](const Stamp* stamp) {
+        m_view->setCurrentStamp(stamp);
+        m_view->setTool(Tool::StampPaint);
     });
     connect(m_minimap,   &Minimap::panRequested,   this,   &MainWindow::onMinimapPan);
 }
@@ -125,6 +161,8 @@ void MainWindow::setupMenus()
     const ToolDef defs[] = {
         { "Tile &Paint",      Tool::TilePaint,       Qt::Key_T },
         { "Tile P&ick",       Tool::TilePick,        Qt::Key_I },
+        { "&Rect Select",     Tool::RectSelect,      Qt::Key_R },
+        { "&Stamp Paint",     Tool::StampPaint,      Qt::Key_M },
         { "Place &Outpost",   Tool::PlaceOutpost,    Qt::Key_O },
         { "Place &Spawnpoint",Tool::PlaceSpawnpoint, Qt::Key_S },
         { "Se&lect Object",   Tool::SelectObject,    Qt::Key_V },
@@ -166,6 +204,12 @@ void MainWindow::setupMenus()
     auto* tilePanelAct = m_tilePanel->toggleViewAction();
     tilePanelAct->setText("&Tile Panel");
     view->addAction(tilePanelAct);
+    auto* tileBrowserAct = m_tileBrowser->toggleViewAction();
+    tileBrowserAct->setText("Tile &Browser");
+    view->addAction(tileBrowserAct);
+    auto* stampPanelAct = m_stampPanel->toggleViewAction();
+    stampPanelAct->setText("&Stamps");
+    view->addAction(stampPanelAct);
     auto* minimapAct = m_minimap->toggleViewAction();
     minimapAct->setText("&Minimap");
     view->addAction(minimapAct);
@@ -189,6 +233,8 @@ void MainWindow::setupToolbar()
     const struct { const char* lbl; Tool t; } tbs[] = {
         {"Paint",     Tool::TilePaint},
         {"Pick",      Tool::TilePick},
+        {"Rect Sel",  Tool::RectSelect},
+        {"Stamp",     Tool::StampPaint},
         {"Outpost",   Tool::PlaceOutpost},
         {"Spawn",     Tool::PlaceSpawnpoint},
         {"Select",    Tool::SelectObject},
@@ -281,11 +327,15 @@ void MainWindow::applyTileset()
     if (m_tileset.isValid()) {
         m_view->setTileset(&m_tileset);
         m_tilePanel->setTileset(&m_tileset);
+        m_tileBrowser->setTileset(&m_tileset);
+        m_stampPanel->setTileset(&m_tileset);
         m_minimap->setTileset(&m_tileset);
         m_minimap->rebuildImage();
     } else {
         m_view->setTileset(nullptr);
         m_tilePanel->setTileset(nullptr);
+        m_tileBrowser->setTileset(nullptr);
+        m_stampPanel->setTileset(nullptr);
         m_minimap->setTileset(nullptr);
     }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -24,7 +24,10 @@
 #include <QKeySequence>
 #include <QCloseEvent>
 #include <QTime>
+#include <QSettings>
 #include <cmath>
+
+static constexpr int MAX_RECENT = 8;
 
 // ---------------------------------------------------------------------------
 // Constructor
@@ -109,6 +112,9 @@ void MainWindow::setupMenus()
     QAction* openAct = file->addAction("&Open…");
     openAct->setShortcut(QKeySequence::Open);
     connect(openAct, &QAction::triggered, this, &MainWindow::onOpen);
+
+    m_recentMenu = file->addMenu("Open &Recent");
+    connect(m_recentMenu, &QMenu::aboutToShow, this, &MainWindow::populateRecentMenu);
 
     file->addSeparator();
 
@@ -270,6 +276,33 @@ void MainWindow::setCurrentFile(const QString& path)
 }
 
 // ---------------------------------------------------------------------------
+// Recent files
+
+void MainWindow::addToRecentFiles(const QString& path)
+{
+    QSettings s;
+    QStringList files = s.value("recentFiles").toStringList();
+    files.removeAll(path);
+    files.prepend(path);
+    while (files.size() > MAX_RECENT)
+        files.removeLast();
+    s.setValue("recentFiles", files);
+}
+
+void MainWindow::populateRecentMenu()
+{
+    m_recentMenu->clear();
+    const QStringList files = QSettings().value("recentFiles").toStringList();
+    for (const QString& path : files) {
+        QAction* a = m_recentMenu->addAction(QFileInfo(path).fileName());
+        a->setToolTip(path);
+        connect(a, &QAction::triggered, this, [this, path]() { openFile(path); });
+    }
+    if (files.isEmpty())
+        m_recentMenu->addAction("(none)")->setEnabled(false);
+}
+
+// ---------------------------------------------------------------------------
 // Tileset search + apply
 
 QString MainWindow::findTileset(const QString& mapPath,
@@ -325,15 +358,8 @@ void MainWindow::applyTileset()
 // ---------------------------------------------------------------------------
 // File actions
 
-void MainWindow::onOpen()
+void MainWindow::openFile(const QString& fn)
 {
-    if (!maybeSave()) return;
-
-    const QString fn = QFileDialog::getOpenFileName(
-        this, "Open map", m_currentFile,
-        "netPanzer maps (*.npm);;Text maps (*.txt);;All files (*)");
-    if (fn.isEmpty()) return;
-
     Map m = MapLoader::load(fn);
     if (!m.isValid()) {
         QMessageBox::warning(this, "Open failed", "Could not load:\n" + fn);
@@ -345,6 +371,7 @@ void MainWindow::onOpen()
     setCurrentFile(fn);
     m_undoAct->setEnabled(false);
     m_redoAct->setEnabled(false);
+    addToRecentFiles(fn);
 
     // Auto-detect tileset
     const QString tsPath = findTileset(fn, m.tileSetName);
@@ -364,6 +391,18 @@ void MainWindow::onOpen()
     }
 
     m_view->fitToWindow();
+}
+
+void MainWindow::onOpen()
+{
+    if (!maybeSave()) return;
+
+    const QString fn = QFileDialog::getOpenFileName(
+        this, "Open map", m_currentFile,
+        "netPanzer maps (*.npm);;Text maps (*.txt);;All files (*)");
+    if (fn.isEmpty()) return;
+
+    openFile(fn);
 }
 
 // Build a copy of the current map with the thumbnail populated from the

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,6 +51,10 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
     connect(m_view, &MapView::viewportChanged,        this, &MainWindow::onViewportChanged);
 
     connect(m_tilePanel, &TilePanel::tileSelected, m_view, &MapView::setSelectedTile);
+    connect(m_view, &MapView::tilePicked, this, [this](int id) {
+        m_view->setSelectedTile(id);
+        m_tilePanel->setSelectedTile(id);
+    });
     connect(m_minimap,   &Minimap::panRequested,   this,   &MainWindow::onMinimapPan);
 }
 
@@ -120,6 +124,7 @@ void MainWindow::setupMenus()
     struct ToolDef { const char* label; Tool tool; QKeySequence key; };
     const ToolDef defs[] = {
         { "Tile &Paint",      Tool::TilePaint,       Qt::Key_T },
+        { "Tile P&ick",       Tool::TilePick,        Qt::Key_I },
         { "Place &Outpost",   Tool::PlaceOutpost,    Qt::Key_O },
         { "Place &Spawnpoint",Tool::PlaceSpawnpoint, Qt::Key_S },
         { "Se&lect Object",   Tool::SelectObject,    Qt::Key_V },
@@ -183,6 +188,7 @@ void MainWindow::setupToolbar()
     // Tools (checkable buttons mirroring the menu)
     const struct { const char* lbl; Tool t; } tbs[] = {
         {"Paint",     Tool::TilePaint},
+        {"Pick",      Tool::TilePick},
         {"Outpost",   Tool::PlaceOutpost},
         {"Spawn",     Tool::PlaceSpawnpoint},
         {"Select",    Tool::SelectObject},

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -157,21 +157,22 @@ void MainWindow::setupMenus()
     m_toolGroup = new QActionGroup(this);
     m_toolGroup->setExclusive(true);
 
-    struct ToolDef { const char* label; Tool tool; QKeySequence key; };
+    struct ToolDef { const char* label; const char* iconText; Tool tool; QKeySequence key; };
     const ToolDef defs[] = {
-        { "Tile &Paint",      Tool::TilePaint,       Qt::Key_T },
-        { "Tile P&ick",       Tool::TilePick,        Qt::Key_I },
-        { "&Rect Select",     Tool::RectSelect,      Qt::Key_R },
-        { "&Stamp Paint",     Tool::StampPaint,      Qt::Key_M },
-        { "Place &Outpost",   Tool::PlaceOutpost,    Qt::Key_O },
-        { "Place &Spawnpoint",Tool::PlaceSpawnpoint, Qt::Key_S },
-        { "Se&lect Object",   Tool::SelectObject,    Qt::Key_V },
+        { "Tile &Paint",       "Paint",    Tool::TilePaint,       Qt::Key_T },
+        { "Tile P&ick",        "Pick",     Tool::TilePick,        Qt::Key_I },
+        { "&Rect Select",      "Rect Sel", Tool::RectSelect,      Qt::Key_R },
+        { "&Stamp Paint",      "Stamp",    Tool::StampPaint,      Qt::Key_M },
+        { "Place &Outpost",    "Outpost",  Tool::PlaceOutpost,    Qt::Key_O },
+        { "Place &Spawnpoint", "Spawn",    Tool::PlaceSpawnpoint, Qt::Key_S },
+        { "Se&lect Object",    "Select",   Tool::SelectObject,    Qt::Key_V },
     };
     for (const auto& d : defs) {
         QAction* a = tools->addAction(d.label);
         a->setCheckable(true);
         a->setShortcut(d.key);
         a->setData(int(d.tool));
+        a->setIconText(d.iconText);
         m_toolGroup->addAction(a);
         connect(a, &QAction::triggered, this, [this, t = d.tool]() { onSetTool(t); });
     }
@@ -229,29 +230,10 @@ void MainWindow::setupToolbar()
     tb->addAction("Zoom Out", this, &MainWindow::onZoomOut);
     tb->addSeparator();
 
-    // Tools (checkable buttons mirroring the menu)
-    const struct { const char* lbl; Tool t; } tbs[] = {
-        {"Paint",     Tool::TilePaint},
-        {"Pick",      Tool::TilePick},
-        {"Rect Sel",  Tool::RectSelect},
-        {"Stamp",     Tool::StampPaint},
-        {"Outpost",   Tool::PlaceOutpost},
-        {"Spawn",     Tool::PlaceSpawnpoint},
-        {"Select",    Tool::SelectObject},
-    };
-    for (const auto& b : tbs) {
-        QAction* a = tb->addAction(b.lbl);
-        a->setCheckable(true);
-        a->setData(int(b.t));
-        // keep in sync with menu tool group
-        connect(a, &QAction::triggered, this, [this, t = b.t]() { onSetTool(t); });
-        connect(m_toolGroup, &QActionGroup::triggered, this,
-                [a, t = b.t](QAction* checked) {
-                    a->setChecked(checked->data().toInt() == int(t));
-                });
-    }
-    // Default: Paint selected
-    tb->actions().last()->parent(); // noop — first tool action already checked
+    // Tools — reuse the same QAction objects from the menu so they share
+    // checked state and the exclusive group handles mutual exclusivity.
+    for (QAction* a : m_toolGroup->actions())
+        tb->addAction(a);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -601,8 +601,8 @@ void MainWindow::onSetTool(Tool t)
     // Sync tile panel: only useful when painting
     m_tilePanel->setVisible(t == Tool::TilePaint);
 
-    const char* names[] = {"Tile Paint", "Place Outpost",
-                            "Place Spawnpoint", "Select Object"};
+    const char* names[] = {"Tile Paint", "Tile Pick", "Rect Select", "Stamp Paint",
+                            "Place Outpost", "Place Spawnpoint", "Select Object"};
     statusBar()->showMessage(
         QString("Tool: %1").arg(names[int(t)]), 2000);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -13,6 +13,7 @@ class Minimap;
 class QLabel;
 class QAction;
 class QActionGroup;
+class QMenu;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -22,6 +23,7 @@ public:
 private slots:
     void onOpen();
     void onSave();
+    void populateRecentMenu();
     void onSaveAs();
     void onNewMap();
     void onLoadTileset();
@@ -49,6 +51,8 @@ private:
     void setCurrentFile(const QString& path);
     void updateTitle();
     void applyTileset();
+    void openFile(const QString& path);
+    void addToRecentFiles(const QString& path);
     QString findTileset(const QString& mapPath, const QString& tileSetName) const;
     // Returns true if it is safe to discard the current map (no unsaved changes,
     // or the user chose to save/discard). Returns false if the user cancelled.
@@ -63,10 +67,11 @@ private:
     QLabel*       m_statusZoom = nullptr;
     QLabel*       m_statusObj  = nullptr;
 
-    QAction*      m_undoAct   = nullptr;
-    QAction*      m_redoAct   = nullptr;
-    QAction*      m_saveAct   = nullptr;
-    QActionGroup* m_toolGroup = nullptr;
+    QAction*      m_undoAct    = nullptr;
+    QAction*      m_redoAct    = nullptr;
+    QAction*      m_saveAct    = nullptr;
+    QActionGroup* m_toolGroup  = nullptr;
+    QMenu*        m_recentMenu = nullptr;
 
     QString m_currentFile;
     bool    m_modified = false;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -7,6 +7,8 @@
 
 class MapView;
 class TilePanel;
+class TileBrowser;
+class StampPanel;
 class Minimap;
 class QLabel;
 class QAction;
@@ -52,9 +54,11 @@ private:
     // or the user chose to save/discard). Returns false if the user cancelled.
     bool maybeSave();
 
-    MapView*      m_view      = nullptr;
-    TilePanel*    m_tilePanel = nullptr;
-    Minimap*      m_minimap   = nullptr;
+    MapView*      m_view        = nullptr;
+    TilePanel*    m_tilePanel   = nullptr;
+    TileBrowser*  m_tileBrowser = nullptr;
+    StampPanel*   m_stampPanel  = nullptr;
+    Minimap*      m_minimap     = nullptr;
     QLabel*       m_statusTile = nullptr;
     QLabel*       m_statusZoom = nullptr;
     QLabel*       m_statusObj  = nullptr;

--- a/src/maploader.cpp
+++ b/src/maploader.cpp
@@ -82,7 +82,11 @@ void MapLoader::loadSpn(const QString& path, Map& m)
     QFile f(path);
     if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
         return;
-    QTextStream in(&f);
+
+    // Some .spn files have no newlines between tokens; normalize before parsing.
+    QString text = QString::fromLatin1(f.readAll());
+    text.replace("Location:", "\nLocation:");
+    QTextStream in(&text, QIODevice::ReadOnly);
 
     while (!in.atEnd()) {
         QString line = in.readLine().trimmed();

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -78,10 +78,11 @@ void MapView::setTool(Tool t)
     emit objectSelectionChanged(-1);
 
     switch (t) {
-    case Tool::SelectObject:   setCursor(Qt::ArrowCursor); break;
+    case Tool::TilePick:        setCursor(Qt::PointingHandCursor); break;
+    case Tool::SelectObject:    setCursor(Qt::ArrowCursor); break;
     case Tool::PlaceOutpost:
     case Tool::PlaceSpawnpoint: setCursor(Qt::CrossCursor); break;
-    default:                   setCursor(Qt::ArrowCursor); break;
+    default:                    setCursor(Qt::ArrowCursor); break;
     }
 }
 
@@ -357,6 +358,16 @@ void MapView::mousePressEvent(QMouseEvent* ev)
     if (ev->button() != Qt::LeftButton) return;
 
     switch (m_tool) {
+    case Tool::TilePick: {
+        int tx, ty;
+        if (widgetToTile(ev->pos(), tx, ty)) {
+            const int id = m_map.tiles[size_t(ty * m_map.width + tx)];
+            m_selectedTile = id;
+            emit tilePicked(id);
+            setTool(Tool::TilePaint);
+        }
+        break;
+    }
     case Tool::TilePaint: {
         startStroke();
         int tx, ty;

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -79,6 +79,8 @@ void MapView::setTool(Tool t)
 
     switch (t) {
     case Tool::TilePick:        setCursor(Qt::PointingHandCursor); break;
+    case Tool::RectSelect:      setCursor(Qt::CrossCursor); break;
+    case Tool::StampPaint:      setCursor(Qt::CrossCursor); break;
     case Tool::SelectObject:    setCursor(Qt::ArrowCursor); break;
     case Tool::PlaceOutpost:
     case Tool::PlaceSpawnpoint: setCursor(Qt::CrossCursor); break;
@@ -165,6 +167,59 @@ void MapView::redo()
     emit objectSelectionChanged(-1);
     update();
     emit mapModified();
+}
+
+// ---------------------------------------------------------------------------
+// Rect selection / stamp
+
+Stamp MapView::captureSelection() const
+{
+    Stamp s;
+    if (m_selection.isNull() || !m_map.isValid()) return s;
+    const int x0 = std::max(0, m_selection.x());
+    const int y0 = std::max(0, m_selection.y());
+    const int x1 = std::min(m_map.width  - 1, m_selection.right());
+    const int y1 = std::min(m_map.height - 1, m_selection.bottom());
+    s.width  = x1 - x0 + 1;
+    s.height = y1 - y0 + 1;
+    s.tiles.resize(size_t(s.width * s.height));
+    for (int row = 0; row < s.height; ++row)
+        for (int col = 0; col < s.width; ++col)
+            s.tiles[size_t(row * s.width + col)] =
+                m_map.tiles[size_t((y0 + row) * m_map.width + (x0 + col))];
+    return s;
+}
+
+void MapView::setCurrentStamp(const Stamp* stamp)
+{
+    m_currentStamp   = stamp;
+    m_stampHoverTile = QPoint(-1, -1);
+    update();
+}
+
+void MapView::applyStamp(int tx, int ty)
+{
+    if (!m_currentStamp || !m_map.isValid()) return;
+    auto batch = std::make_unique<TileBatch>();
+    for (int row = 0; row < m_currentStamp->height; ++row) {
+        for (int col = 0; col < m_currentStamp->width; ++col) {
+            const int mtx = tx + col;
+            const int mty = ty + row;
+            if (mtx < 0 || mty < 0 || mtx >= m_map.width || mty >= m_map.height)
+                continue;
+            const int idx = mty * m_map.width + mtx;
+            const uint16_t oldVal = m_map.tiles[size_t(idx)];
+            const uint16_t newVal = m_currentStamp->tiles[size_t(row * m_currentStamp->width + col)];
+            if (oldVal == newVal) continue;
+            m_map.tiles[size_t(idx)] = newVal;
+            batch->edits.push_back({idx, oldVal, newVal});
+        }
+    }
+    if (!batch->empty()) {
+        pushCommand(std::move(batch));
+        update();
+        emit mapModified();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -273,6 +328,38 @@ void MapView::paintEvent(QPaintEvent*)
             }
     }
 
+    // Stamp ghost preview
+    if (m_tool == Tool::StampPaint && m_currentStamp &&
+        m_stampHoverTile.x() >= 0 && !m_atlasPixmap.isNull()) {
+        const int tx = m_stampHoverTile.x();
+        const int ty = m_stampHoverTile.y();
+        p.setOpacity(0.55);
+        for (int row = 0; row < m_currentStamp->height; ++row) {
+            for (int col = 0; col < m_currentStamp->width; ++col) {
+                const int id  = m_currentStamp->tiles[size_t(row * m_currentStamp->width + col)];
+                const QRect src = m_tileset->atlasRect(id, ATLAS_COLS);
+                p.drawPixmap(
+                    QRectF((tx + col) * TILE_SIZE, (ty + row) * TILE_SIZE, TILE_SIZE, TILE_SIZE),
+                    m_atlasPixmap, QRectF(src));
+            }
+        }
+        p.setOpacity(1.0);
+    }
+
+    // Selection highlight
+    if (!m_selection.isNull()) {
+        const QRectF selRect(m_selection.x() * TILE_SIZE,
+                             m_selection.y() * TILE_SIZE,
+                             m_selection.width()  * TILE_SIZE,
+                             m_selection.height() * TILE_SIZE);
+        p.setOpacity(0.25);
+        p.fillRect(selRect, QColor(255, 220, 0));
+        p.setOpacity(1.0);
+        p.setBrush(Qt::NoBrush);
+        p.setPen(QPen(QColor(255, 220, 0), 0));
+        p.drawRect(selRect);
+    }
+
     // Grid
     if (m_showGrid && m_zoom > 0.2) {
         p.setPen(QPen(QColor(0, 0, 0, 80), 0));
@@ -368,6 +455,23 @@ void MapView::mousePressEvent(QMouseEvent* ev)
         }
         break;
     }
+    case Tool::RectSelect: {
+        int tx, ty;
+        if (widgetToTile(ev->pos(), tx, ty)) {
+            m_selecting   = true;
+            m_selectStart = QPoint(tx, ty);
+            m_selection   = QRect(tx, ty, 1, 1);
+            emit selectionChanged(m_selection);
+            update();
+        }
+        break;
+    }
+    case Tool::StampPaint: {
+        int tx, ty;
+        if (widgetToTile(ev->pos(), tx, ty))
+            applyStamp(tx, ty);
+        break;
+    }
     case Tool::TilePaint: {
         startStroke();
         int tx, ty;
@@ -443,6 +547,29 @@ void MapView::mouseMoveEvent(QMouseEvent* ev)
             addToStroke(tx, ty);
     }
 
+    if (m_tool == Tool::RectSelect && m_selecting && (ev->buttons() & Qt::LeftButton)) {
+        int tx, ty;
+        if (widgetToTile(ev->pos(), tx, ty)) {
+            const int x0 = std::min(m_selectStart.x(), tx);
+            const int y0 = std::min(m_selectStart.y(), ty);
+            const int x1 = std::max(m_selectStart.x(), tx);
+            const int y1 = std::max(m_selectStart.y(), ty);
+            m_selection = QRect(x0, y0, x1 - x0 + 1, y1 - y0 + 1);
+            emit selectionChanged(m_selection);
+            update();
+        }
+    }
+
+    if (m_tool == Tool::StampPaint) {
+        int tx, ty;
+        const QPoint newHover = widgetToTile(ev->pos(), tx, ty)
+                                ? QPoint(tx, ty) : QPoint(-1, -1);
+        if (newHover != m_stampHoverTile) {
+            m_stampHoverTile = newHover;
+            update();
+        }
+    }
+
     if (m_tool == Tool::SelectObject && m_draggingObj &&
         m_selectedObj >= 0 && (ev->buttons() & Qt::LeftButton)) {
         int tx, ty;
@@ -477,6 +604,11 @@ void MapView::mouseReleaseEvent(QMouseEvent* ev)
         if (m_tool == Tool::TilePaint)
             commitStroke();
 
+        if (m_tool == Tool::RectSelect && m_selecting) {
+            m_selecting = false;
+            // selection already updated in mouseMoveEvent
+        }
+
         if (m_tool == Tool::SelectObject && m_draggingObj && m_selectedObj >= 0) {
             const auto& obj = m_map.objects[size_t(m_selectedObj)];
             if (obj.x != m_objDragOrigX || obj.y != m_objDragOrigY) {
@@ -499,6 +631,10 @@ void MapView::leaveEvent(QEvent*)
 {
     commitStroke();
     m_draggingObj = false;
+    if (m_tool == Tool::StampPaint && m_stampHoverTile.x() >= 0) {
+        m_stampHoverTile = QPoint(-1, -1);
+        update();
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -567,6 +567,8 @@ void MapView::mouseMoveEvent(QMouseEvent* ev)
         if (newHover != m_stampHoverTile) {
             m_stampHoverTile = newHover;
             update();
+            if ((ev->buttons() & Qt::LeftButton) && newHover.x() >= 0)
+                applyStamp(tx, ty);
         }
     }
 

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -8,6 +8,7 @@
 #include <QMenu>
 #include <QInputDialog>
 #include <algorithm>
+#include <cmath>
 
 // ---------------------------------------------------------------------------
 // Construction
@@ -76,10 +77,12 @@ void MapView::setTool(Tool t)
     m_draggingObj = false;
     m_selectedObj = -1;
     m_outpostHoverTile = QPoint(-1, -1);
+    m_ellipseActive = false;
     emit objectSelectionChanged(-1);
 
     switch (t) {
     case Tool::TilePick:        setCursor(Qt::PointingHandCursor); break;
+    case Tool::EllipsePaint:
     case Tool::RectSelect:      setCursor(Qt::CrossCursor); break;
     case Tool::StampPaint:      setCursor(Qt::CrossCursor); break;
     case Tool::SelectObject:    setCursor(Qt::ArrowCursor); break;
@@ -285,6 +288,36 @@ void MapView::deleteSelectedObject()
 }
 
 // ---------------------------------------------------------------------------
+// Ellipse outline tile set (parametric, sufficient steps to avoid gaps)
+
+std::vector<QPoint> MapView::computeEllipseTiles(QPoint a, QPoint b, int mapW, int mapH)
+{
+    const double cx = (a.x() + b.x()) / 2.0;
+    const double cy = (a.y() + b.y()) / 2.0;
+    const double rx = std::abs(b.x() - a.x()) / 2.0;
+    const double ry = std::abs(b.y() - a.y()) / 2.0;
+
+    // Approximate perimeter (Ramanujan) to choose step count
+    const double h    = ((rx - ry) * (rx - ry)) / ((rx + ry) * (rx + ry) + 1e-9);
+    const double peri = M_PI * (rx + ry) * (1 + 3*h / (10 + std::sqrt(4 - 3*h)));
+    const int steps   = std::max(8, int(std::ceil(peri * 2)));
+
+    std::vector<bool>   visited(size_t(mapW * mapH), false);
+    std::vector<QPoint> result;
+    for (int i = 0; i < steps; ++i) {
+        const double angle = 2.0 * M_PI * i / steps;
+        const int tx = std::clamp(int(std::round(cx + rx * std::cos(angle))), 0, mapW - 1);
+        const int ty = std::clamp(int(std::round(cy + ry * std::sin(angle))), 0, mapH - 1);
+        const size_t idx = size_t(ty * mapW + tx);
+        if (!visited[idx]) {
+            visited[idx] = true;
+            result.push_back(QPoint(tx, ty));
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
 // Paint event
 
 void MapView::paintEvent(QPaintEvent*)
@@ -401,6 +434,19 @@ void MapView::paintEvent(QPaintEvent*)
         }
     }
 
+    // Ellipse paint preview
+    if (m_tool == Tool::EllipsePaint && m_ellipseActive) {
+        const auto tiles = computeEllipseTiles(m_ellipseStart, m_ellipseEnd,
+                                               m_map.width, m_map.height);
+        p.setOpacity(0.55);
+        p.setPen(Qt::NoPen);
+        p.setBrush(QColor(255, 220, 0));
+        for (const QPoint& pt : tiles)
+            p.fillRect(QRectF(pt.x() * TILE_SIZE, pt.y() * TILE_SIZE,
+                              TILE_SIZE, TILE_SIZE), QColor(255, 220, 0, 180));
+        p.setOpacity(1.0);
+    }
+
     // Outpost capture-pad overlay.
     // The game places the pad at marker_center + (224, 48) px with a
     // ±48 x ±32 px capture box (Objective.cpp, occupation_pad_offset).
@@ -478,6 +524,16 @@ void MapView::mousePressEvent(QMouseEvent* ev)
     if (ev->button() != Qt::LeftButton) return;
 
     switch (m_tool) {
+    case Tool::EllipsePaint: {
+        int tx, ty;
+        if (widgetToTile(ev->pos(), tx, ty)) {
+            m_ellipseStart  = QPoint(tx, ty);
+            m_ellipseEnd    = QPoint(tx, ty);
+            m_ellipseActive = true;
+            update();
+        }
+        break;
+    }
     case Tool::TilePick: {
         int tx, ty;
         if (widgetToTile(ev->pos(), tx, ty)) {
@@ -593,6 +649,17 @@ void MapView::mouseMoveEvent(QMouseEvent* ev)
         }
     }
 
+    if (m_tool == Tool::EllipsePaint && m_ellipseActive && (ev->buttons() & Qt::LeftButton)) {
+        int tx, ty;
+        if (widgetToTile(ev->pos(), tx, ty)) {
+            const QPoint newEnd(tx, ty);
+            if (newEnd != m_ellipseEnd) {
+                m_ellipseEnd = newEnd;
+                update();
+            }
+        }
+    }
+
     if (m_tool == Tool::PlaceOutpost) {
         int tx, ty;
         const QPoint newHover = widgetToTile(ev->pos(), tx, ty)
@@ -646,6 +713,27 @@ void MapView::mouseReleaseEvent(QMouseEvent* ev)
     }
 
     if (ev->button() == Qt::LeftButton) {
+        if (m_tool == Tool::EllipsePaint && m_ellipseActive) {
+            m_ellipseActive = false;
+            const auto tiles = computeEllipseTiles(m_ellipseStart, m_ellipseEnd,
+                                                   m_map.width, m_map.height);
+            auto batch = std::make_unique<TileBatch>();
+            for (const QPoint& pt : tiles) {
+                const int idx     = pt.y() * m_map.width + pt.x();
+                const uint16_t ov = m_map.tiles[size_t(idx)];
+                const uint16_t nv = uint16_t(m_selectedTile);
+                if (ov != nv) {
+                    m_map.tiles[size_t(idx)] = nv;
+                    batch->edits.push_back({idx, ov, nv});
+                }
+            }
+            if (!batch->empty()) {
+                pushCommand(std::move(batch));
+                emit mapModified();
+            }
+            update();
+        }
+
         if (m_tool == Tool::TilePaint)
             commitStroke();
 

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -9,6 +9,9 @@
 #include <QInputDialog>
 #include <algorithm>
 #include <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 // ---------------------------------------------------------------------------
 // Construction

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -75,6 +75,7 @@ void MapView::setTool(Tool t)
     commitStroke();
     m_draggingObj = false;
     m_selectedObj = -1;
+    m_outpostHoverTile = QPoint(-1, -1);
     emit objectSelectionChanged(-1);
 
     switch (t) {
@@ -400,6 +401,36 @@ void MapView::paintEvent(QPaintEvent*)
         }
     }
 
+    // Outpost capture-pad overlay.
+    // The game places the pad at marker_center + (224, 48) px with a
+    // ±48 x ±32 px capture box (Objective.cpp, occupation_pad_offset).
+    auto drawCapturePad = [&](QPointF markerCentre, bool ghost) {
+        const QPointF padCentre = markerCentre + QPointF(224, 48);
+        const QRectF  padRect(padCentre.x() - 48, padCentre.y() - 32, 96, 64);
+        p.setOpacity(ghost ? 0.45 : 0.75);
+        p.setBrush(QColor(255, 200, 0, 50));
+        p.setPen(QPen(QColor(255, 200, 0), ghost ? 0.5 : 1.0));
+        p.drawRect(padRect);
+        p.setBrush(Qt::NoBrush);
+        p.setPen(QPen(QColor(255, 200, 0, 160), 0.5, Qt::DashLine));
+        p.drawLine(markerCentre, padCentre);
+        p.setOpacity(1.0);
+    };
+
+    // Selected outpost
+    if (m_selectedObj >= 0 && m_selectedObj < int(m_map.objects.size())) {
+        const auto& obj = m_map.objects[size_t(m_selectedObj)];
+        if (obj.type == "outpost")
+            drawCapturePad(QPointF((obj.x + 0.5) * TILE_SIZE,
+                                   (obj.y + 0.5) * TILE_SIZE), false);
+    }
+
+    // Ghost while hovering to place
+    if (m_tool == Tool::PlaceOutpost && m_outpostHoverTile.x() >= 0) {
+        drawCapturePad(QPointF((m_outpostHoverTile.x() + 0.5) * TILE_SIZE,
+                                (m_outpostHoverTile.y() + 0.5) * TILE_SIZE), true);
+    }
+
     // Map border
     p.setBrush(Qt::NoBrush);
     p.setPen(QPen(QColor(200, 200, 200), 0));
@@ -562,6 +593,16 @@ void MapView::mouseMoveEvent(QMouseEvent* ev)
         }
     }
 
+    if (m_tool == Tool::PlaceOutpost) {
+        int tx, ty;
+        const QPoint newHover = widgetToTile(ev->pos(), tx, ty)
+                                ? QPoint(tx, ty) : QPoint(-1, -1);
+        if (newHover != m_outpostHoverTile) {
+            m_outpostHoverTile = newHover;
+            update();
+        }
+    }
+
     if (m_tool == Tool::StampPaint) {
         int tx, ty;
         const QPoint newHover = widgetToTile(ev->pos(), tx, ty)
@@ -637,6 +678,10 @@ void MapView::leaveEvent(QEvent*)
     m_draggingObj = false;
     if (m_tool == Tool::StampPaint && m_stampHoverTile.x() >= 0) {
         m_stampHoverTile = QPoint(-1, -1);
+        update();
+    }
+    if (m_tool == Tool::PlaceOutpost && m_outpostHoverTile.x() >= 0) {
+        m_outpostHoverTile = QPoint(-1, -1);
         update();
     }
 }

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -111,7 +111,9 @@ int MapView::objectAt(QPoint wpos) const
 {
     if (m_map.objects.empty()) return -1;
     const QPointF mp = widgetToMapPx(wpos);
-    const double hitR = TILE_SIZE * 0.6;
+    // Enforce a minimum hit radius of 8 screen pixels so objects remain
+    // clickable at low zoom levels.
+    const double hitR = std::max(TILE_SIZE * 0.6, 8.0 / m_zoom);
     // Iterate in reverse so topmost-drawn object wins
     for (int i = int(m_map.objects.size()) - 1; i >= 0; --i) {
         const auto& obj = m_map.objects[size_t(i)];
@@ -376,7 +378,7 @@ void MapView::paintEvent(QPaintEvent*)
     for (int i = 0; i < int(m_map.objects.size()); ++i) {
         const auto& obj = m_map.objects[size_t(i)];
         const QPointF centre((obj.x + 0.5) * TILE_SIZE, (obj.y + 0.5) * TILE_SIZE);
-        const double r = TILE_SIZE * 0.45;
+        const double r = std::max(TILE_SIZE * 0.45, 5.0 / m_zoom);
 
         const bool selected = (i == m_selectedObj);
         QColor fill = (obj.type == "outpost") ? QColor(220, 60, 60, 210)

--- a/src/mapview.h
+++ b/src/mapview.h
@@ -13,6 +13,7 @@
 
 enum class Tool {
     TilePaint,       // left-drag paints selected tile
+    TilePick,        // left-click picks tile under cursor, switches to TilePaint
     PlaceOutpost,    // left-click places an outpost
     PlaceSpawnpoint, // left-click places a spawn point
     SelectObject     // left-click selects/drags objects; Del removes
@@ -67,6 +68,7 @@ public:
 
 signals:
     void tileHovered(int tileX, int tileY, int tileId);
+    void tilePicked(int tileId);   // emitted when TilePick tool clicks a tile
     void mapModified();
     void objectSelectionChanged(int idx); // -1 = none
     void objectActivated(int idx);        // double-click on an object

--- a/src/mapview.h
+++ b/src/mapview.h
@@ -142,6 +142,9 @@ private:
     const Stamp* m_currentStamp    = nullptr;
     QPoint       m_stampHoverTile  = QPoint(-1, -1);
 
+    // Outpost placement hover (tile coords, (-1,-1) = none)
+    QPoint m_outpostHoverTile = QPoint(-1, -1);
+
     // Pan state (middle button)
     bool   m_panning   = false;
     QPoint m_lastMouse;

--- a/src/mapview.h
+++ b/src/mapview.h
@@ -2,6 +2,7 @@
 #include <QWidget>
 #include <QPoint>
 #include <QPointF>
+#include <QRect>
 #include <QRectF>
 #include <QPixmap>
 #include <QSet>
@@ -10,10 +11,13 @@
 #include "objects.h"
 #include "tlsloader.h"
 #include "commands.h"
+#include "stamp.h"
 
 enum class Tool {
     TilePaint,       // left-drag paints selected tile
     TilePick,        // left-click picks tile under cursor, switches to TilePaint
+    RectSelect,      // drag to select a rectangular tile region
+    StampPaint,      // click to place the current stamp
     PlaceOutpost,    // left-click places an outpost
     PlaceSpawnpoint, // left-click places a spawn point
     SelectObject     // left-click selects/drags objects; Del removes
@@ -45,6 +49,14 @@ public:
     void setSelectedTile(int id) { m_selectedTile = id; }
     int  selectedTile()   const  { return m_selectedTile; }
 
+    // Rect selection
+    QRect selection() const { return m_selection; }
+    bool  hasSelection() const { return !m_selection.isNull(); }
+    Stamp captureSelection() const;
+
+    // Stamp painting
+    void setCurrentStamp(const Stamp* stamp);
+
     // View options
     void setShowGrid(bool show) { m_showGrid = show; update(); }
     bool showGrid()       const  { return m_showGrid; }
@@ -68,7 +80,8 @@ public:
 
 signals:
     void tileHovered(int tileX, int tileY, int tileId);
-    void tilePicked(int tileId);   // emitted when TilePick tool clicks a tile
+    void tilePicked(int tileId);        // emitted when TilePick tool clicks a tile
+    void selectionChanged(QRect sel);   // emitted when rect selection changes
     void mapModified();
     void objectSelectionChanged(int idx); // -1 = none
     void objectActivated(int idx);        // double-click on an object
@@ -120,9 +133,20 @@ private:
     int  m_selectedTile = 0;
     int  m_selectedObj  = -1;
 
+    // Rect selection state
+    QRect  m_selection;          // in tile coords, null if none
+    bool   m_selecting  = false;
+    QPoint m_selectStart;        // tile coord where drag began
+
+    // Stamp paint state
+    const Stamp* m_currentStamp    = nullptr;
+    QPoint       m_stampHoverTile  = QPoint(-1, -1);
+
     // Pan state (middle button)
     bool   m_panning   = false;
     QPoint m_lastMouse;
+
+    void applyStamp(int tx, int ty);
 
     // Tile stroke state
     std::unique_ptr<TileBatch> m_currentStroke;

--- a/src/mapview.h
+++ b/src/mapview.h
@@ -15,6 +15,7 @@
 
 enum class Tool {
     TilePaint,       // left-drag paints selected tile
+    EllipsePaint,    // drag to paint selected tile along ellipse outline
     TilePick,        // left-click picks tile under cursor, switches to TilePaint
     RectSelect,      // drag to select a rectangular tile region
     StampPaint,      // click to place the current stamp
@@ -144,6 +145,13 @@ private:
 
     // Outpost placement hover (tile coords, (-1,-1) = none)
     QPoint m_outpostHoverTile = QPoint(-1, -1);
+
+    // Ellipse paint state
+    QPoint m_ellipseStart;
+    QPoint m_ellipseEnd;
+    bool   m_ellipseActive = false;
+
+    static std::vector<QPoint> computeEllipseTiles(QPoint a, QPoint b, int mapW, int mapH);
 
     // Pan state (middle button)
     bool   m_panning   = false;

--- a/src/stamp.h
+++ b/src/stamp.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <QString>
+#include <vector>
+#include <cstdint>
+
+struct Stamp {
+    QString name;
+    int width  = 0;
+    int height = 0;
+    std::vector<uint16_t> tiles; // row-major, width*height entries
+};

--- a/src/stamppanel.cpp
+++ b/src/stamppanel.cpp
@@ -1,0 +1,197 @@
+#include "stamppanel.h"
+#include <QPainter>
+#include <QPaintEvent>
+#include <QMouseEvent>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <algorithm>
+
+// ---------------------------------------------------------------------------
+// StampWidget
+
+StampWidget::StampWidget(QWidget* parent) : QWidget(parent)
+{
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+}
+
+void StampWidget::setTileset(const Tileset* ts)
+{
+    m_tileset     = ts;
+    m_atlasPixmap = QPixmap();
+    m_selected    = -1;
+    update();
+}
+
+void StampWidget::addStamp(Stamp s)
+{
+    m_stamps.push_back(std::move(s));
+    updateGeometry();
+    update();
+}
+
+void StampWidget::clear()
+{
+    m_stamps.clear();
+    m_selected = -1;
+    updateGeometry();
+    update();
+}
+
+const Stamp* StampWidget::selectedStamp() const
+{
+    if (m_selected < 0 || m_selected >= int(m_stamps.size())) return nullptr;
+    return &m_stamps[size_t(m_selected)];
+}
+
+int StampWidget::cols() const
+{
+    const int cell = THUMB + PADDING;
+    return std::max(1, width() / cell);
+}
+
+QSize StampWidget::sizeHint() const
+{
+    if (m_stamps.empty()) return QSize(THUMB + PADDING, THUMB + PADDING + 20);
+    const int c    = std::max(1, cols());
+    const int rows = (int(m_stamps.size()) + c - 1) / c;
+    return QSize(c * (THUMB + PADDING), rows * (THUMB + PADDING + 20));
+}
+
+int StampWidget::stampAt(QPoint pos) const
+{
+    const int cell = THUMB + PADDING;
+    const int labelH = 20;
+    const int c   = cols();
+    const int col = pos.x() / cell;
+    const int row = pos.y() / (cell + labelH);
+    if (col < 0 || col >= c) return -1;
+    const int id = row * c + col;
+    return (id >= 0 && id < int(m_stamps.size())) ? id : -1;
+}
+
+void StampWidget::paintEvent(QPaintEvent*)
+{
+    QPainter p(this);
+    p.fillRect(rect(), QColor(30, 30, 30));
+
+    if (!m_tileset || !m_tileset->isValid() || m_stamps.empty()) {
+        p.setPen(Qt::gray);
+        p.drawText(rect(), Qt::AlignCenter, "No stamps\ncaptured yet");
+        return;
+    }
+
+    if (m_atlasPixmap.isNull())
+        m_atlasPixmap = QPixmap::fromImage(m_tileset->atlas(ATLAS_COLS));
+
+    const int cell   = THUMB + PADDING;
+    const int labelH = 20;
+    const int c      = cols();
+
+    for (int i = 0; i < int(m_stamps.size()); ++i) {
+        const Stamp& s = m_stamps[size_t(i)];
+        const int col  = i % c;
+        const int row  = i / c;
+        const int x    = col * cell + PADDING / 2;
+        const int y    = row * (cell + labelH) + PADDING / 2;
+
+        // Background
+        const bool sel = (i == m_selected);
+        p.fillRect(x, y, THUMB, THUMB, QColor(50, 50, 50));
+
+        // Render stamp tiles into the thumbnail area
+        if (!m_atlasPixmap.isNull() && s.width > 0 && s.height > 0) {
+            const double scaleX = double(THUMB) / (s.width  * 32);
+            const double scaleY = double(THUMB) / (s.height * 32);
+            const double scale  = std::min(scaleX, scaleY);
+            const int thumbW = int(s.width  * 32 * scale);
+            const int thumbH = int(s.height * 32 * scale);
+            const int offX   = x + (THUMB - thumbW) / 2;
+            const int offY   = y + (THUMB - thumbH) / 2;
+            const int tileW  = int(32 * scale);
+            const int tileH  = int(32 * scale);
+
+            for (int row2 = 0; row2 < s.height; ++row2) {
+                for (int col2 = 0; col2 < s.width; ++col2) {
+                    const int id  = s.tiles[size_t(row2 * s.width + col2)];
+                    const QRect src = m_tileset->atlasRect(id, ATLAS_COLS);
+                    p.drawPixmap(offX + col2 * tileW, offY + row2 * tileH, tileW, tileH,
+                                 m_atlasPixmap, src.x(), src.y(), src.width(), src.height());
+                }
+            }
+        }
+
+        // Selection border
+        if (sel) {
+            p.setPen(QPen(QColor(255, 220, 0), 2));
+            p.setBrush(Qt::NoBrush);
+            p.drawRect(x, y, THUMB, THUMB);
+        }
+
+        // Label
+        p.setPen(Qt::lightGray);
+        QFont f = p.font();
+        f.setPixelSize(11);
+        p.setFont(f);
+        p.drawText(x, y + THUMB + 2, THUMB, labelH - 2,
+                   Qt::AlignHCenter | Qt::AlignTop | Qt::TextSingleLine,
+                   s.name.isEmpty() ? QString("Stamp %1").arg(i + 1) : s.name);
+    }
+}
+
+void StampWidget::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) return;
+    const int id = stampAt(ev->pos());
+    if (id >= 0) {
+        m_selected = id;
+        update();
+        emit stampSelected(&m_stamps[size_t(id)]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StampPanel
+
+StampPanel::StampPanel(QWidget* parent)
+    : QDockWidget("Stamps", parent)
+    , m_widget(new StampWidget())
+    , m_scroll(new QScrollArea())
+    , m_captureBtn(new QPushButton("Capture Selection"))
+{
+    setAllowedAreas(Qt::AllDockWidgetAreas);
+    setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable
+                | QDockWidget::DockWidgetClosable);
+
+    m_scroll->setWidget(m_widget);
+    m_scroll->setWidgetResizable(true);
+    m_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+    auto* container = new QWidget();
+    auto* layout    = new QVBoxLayout(container);
+    layout->setContentsMargins(4, 4, 4, 4);
+    layout->setSpacing(4);
+    layout->addWidget(m_captureBtn);
+    layout->addWidget(m_scroll);
+    setWidget(container);
+
+    connect(m_captureBtn, &QPushButton::clicked,
+            this, &StampPanel::captureRequested);
+    connect(m_widget, &StampWidget::stampSelected,
+            this,     &StampPanel::stampSelected);
+}
+
+void StampPanel::addStamp(Stamp s)
+{
+    m_widget->addStamp(std::move(s));
+}
+
+void StampPanel::setTileset(const Tileset* ts)
+{
+    m_widget->setTileset(ts);
+}
+
+const Stamp* StampPanel::selectedStamp() const
+{
+    return m_widget->selectedStamp();
+}

--- a/src/stamppanel.h
+++ b/src/stamppanel.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <QDockWidget>
+#include <QWidget>
+#include <QPixmap>
+#include <QScrollArea>
+#include <QPushButton>
+#include <vector>
+#include "stamp.h"
+#include "tlsloader.h"
+
+class StampWidget : public QWidget {
+    Q_OBJECT
+public:
+    explicit StampWidget(QWidget* parent = nullptr);
+
+    void addStamp(Stamp s);
+    void setTileset(const Tileset* ts);
+    void clear();
+
+    const Stamp* selectedStamp() const;
+
+signals:
+    void stampSelected(const Stamp* stamp);
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    QSize sizeHint() const override;
+
+private:
+    static constexpr int THUMB   = 96;
+    static constexpr int PADDING = 6;
+    static constexpr int ATLAS_COLS = 64;
+    int cols() const;
+    int stampAt(QPoint pos) const;
+
+    const Tileset*     m_tileset = nullptr;
+    QPixmap            m_atlasPixmap;
+    std::vector<Stamp> m_stamps;
+    int                m_selected = -1;
+};
+
+class StampPanel : public QDockWidget {
+    Q_OBJECT
+public:
+    explicit StampPanel(QWidget* parent = nullptr);
+
+    void addStamp(Stamp s);
+    void setTileset(const Tileset* ts);
+    const Stamp* selectedStamp() const;
+
+signals:
+    void stampSelected(const Stamp* stamp);
+    void captureRequested();
+
+private:
+    StampWidget*  m_widget;
+    QScrollArea*  m_scroll;
+    QPushButton*  m_captureBtn;
+};

--- a/src/tilebrowser.cpp
+++ b/src/tilebrowser.cpp
@@ -1,0 +1,245 @@
+#include "tilebrowser.h"
+#include <QPainter>
+#include <QPaintEvent>
+#include <QMouseEvent>
+#include <QVBoxLayout>
+#include <QComboBox>
+#include <QLabel>
+#include <algorithm>
+
+// ---------------------------------------------------------------------------
+// TileBrowserWidget
+
+TileBrowserWidget::TileBrowserWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    setMouseTracking(true);
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+}
+
+void TileBrowserWidget::setTileset(const Tileset* ts)
+{
+    m_tileset     = ts;
+    m_atlasPixmap = QPixmap();
+    m_selectedTile = 0;
+    m_hoveredTile  = -1;
+    updateGeometry();
+    update();
+}
+
+void TileBrowserWidget::setTileSize(int px)
+{
+    m_tileSize = px;
+    updateGeometry();
+    update();
+}
+
+int TileBrowserWidget::cols() const
+{
+    const int available = std::max(width(), m_tileSize);
+    return std::max(1, available / m_tileSize);
+}
+
+QSize TileBrowserWidget::sizeHint() const
+{
+    if (!m_tileset || !m_tileset->isValid())
+        return QSize(4 * m_tileSize, 200);
+    const int c    = std::max(1, 4);
+    const int rows = (m_tileset->tileCount() + c - 1) / c;
+    return QSize(c * m_tileSize, rows * m_tileSize);
+}
+
+QPoint TileBrowserWidget::gridPos(QPoint widgetPos) const
+{
+    return QPoint(widgetPos.x() / m_tileSize, widgetPos.y() / m_tileSize);
+}
+
+int TileBrowserWidget::tileIdAt(QPoint grid) const
+{
+    if (!m_tileset || !m_tileset->isValid()) return -1;
+    const int c = cols();
+    if (grid.x() < 0 || grid.x() >= c || grid.y() < 0) return -1;
+    const int id = grid.y() * c + grid.x();
+    return (id < m_tileset->tileCount()) ? id : -1;
+}
+
+void TileBrowserWidget::paintEvent(QPaintEvent* ev)
+{
+    QPainter p(this);
+    p.fillRect(rect(), QColor(30, 30, 30));
+
+    if (!m_tileset || !m_tileset->isValid()) {
+        p.setPen(Qt::gray);
+        p.drawText(rect(), Qt::AlignCenter, "No tileset");
+        return;
+    }
+
+    if (m_atlasPixmap.isNull())
+        m_atlasPixmap = QPixmap::fromImage(m_tileset->atlas(ATLAS_COLS));
+
+    const int c    = cols();
+    const int rows = (m_tileset->tileCount() + c - 1) / c;
+
+    const QRect dirty = ev->rect();
+    const int firstRow = std::max(0, dirty.top()    / m_tileSize);
+    const int lastRow  = std::min(rows - 1, dirty.bottom() / m_tileSize);
+
+    // Pre-compute the drag-selection rect in grid coords (normalised)
+    const int selC0 = m_dragging ? std::min(m_selStart.x(), m_selEnd.x()) : -1;
+    const int selC1 = m_dragging ? std::max(m_selStart.x(), m_selEnd.x()) : -1;
+    const int selR0 = m_dragging ? std::min(m_selStart.y(), m_selEnd.y()) : -1;
+    const int selR1 = m_dragging ? std::max(m_selStart.y(), m_selEnd.y()) : -1;
+
+    for (int row = firstRow; row <= lastRow; ++row) {
+        for (int col = 0; col < c; ++col) {
+            const int id = row * c + col;
+            if (id >= m_tileset->tileCount()) break;
+
+            const QRect dst(col * m_tileSize, row * m_tileSize, m_tileSize, m_tileSize);
+            const QRect src = m_tileset->atlasRect(id, ATLAS_COLS);
+            p.drawPixmap(dst, m_atlasPixmap, src);
+
+            const bool inSel = m_dragging &&
+                               col >= selC0 && col <= selC1 &&
+                               row >= selR0 && row <= selR1;
+
+            if (inSel) {
+                p.fillRect(dst, QColor(255, 220, 0, 80));
+            }
+            if (id == m_selectedTile && !m_dragging) {
+                p.setPen(QPen(QColor(255, 220, 0), 2));
+                p.setBrush(Qt::NoBrush);
+                p.drawRect(dst.adjusted(1, 1, -1, -1));
+            }
+            if (id == m_hoveredTile && id != m_selectedTile && !m_dragging) {
+                p.fillRect(dst, QColor(255, 255, 255, 40));
+            }
+        }
+    }
+
+    // Selection border
+    if (m_dragging) {
+        const QRect selRect(selC0 * m_tileSize, selR0 * m_tileSize,
+                            (selC1 - selC0 + 1) * m_tileSize,
+                            (selR1 - selR0 + 1) * m_tileSize);
+        p.setPen(QPen(QColor(255, 220, 0), 2));
+        p.setBrush(Qt::NoBrush);
+        p.drawRect(selRect.adjusted(1, 1, -1, -1));
+    }
+}
+
+void TileBrowserWidget::mousePressEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton) return;
+    const QPoint gp = gridPos(ev->pos());
+    if (tileIdAt(gp) < 0) return;
+    m_dragging = true;
+    m_selStart = m_selEnd = gp;
+    update();
+}
+
+void TileBrowserWidget::mouseMoveEvent(QMouseEvent* ev)
+{
+    if (m_dragging) {
+        const QPoint gp = gridPos(ev->pos());
+        if (gp != m_selEnd) {
+            m_selEnd = gp;
+            update();
+        }
+        return;
+    }
+    const int id = tileIdAt(gridPos(ev->pos()));
+    if (id != m_hoveredTile) {
+        m_hoveredTile = id;
+        update();
+    }
+}
+
+void TileBrowserWidget::mouseReleaseEvent(QMouseEvent* ev)
+{
+    if (ev->button() != Qt::LeftButton || !m_dragging) return;
+    m_dragging = false;
+
+    const int colC0 = std::min(m_selStart.x(), m_selEnd.x());
+    const int colC1 = std::max(m_selStart.x(), m_selEnd.x());
+    const int rowR0 = std::min(m_selStart.y(), m_selEnd.y());
+    const int rowR1 = std::max(m_selStart.y(), m_selEnd.y());
+    const int w     = colC1 - colC0 + 1;
+    const int h     = rowR1 - rowR0 + 1;
+
+    if (w == 1 && h == 1) {
+        // Single tile — treat as a normal click
+        const int id = tileIdAt(m_selStart);
+        if (id >= 0) {
+            m_selectedTile = id;
+            emit tileSelected(id);
+        }
+    } else {
+        // Multi-tile — build a stamp
+        Stamp s;
+        s.width  = w;
+        s.height = h;
+        s.tiles.resize(size_t(w * h));
+        for (int row = 0; row < h; ++row) {
+            for (int col = 0; col < w; ++col) {
+                const int id = tileIdAt(QPoint(colC0 + col, rowR0 + row));
+                s.tiles[size_t(row * w + col)] =
+                    uint16_t(id >= 0 ? id : 0);
+            }
+        }
+        emit stampCreated(std::move(s));
+    }
+    update();
+}
+
+void TileBrowserWidget::leaveEvent(QEvent*)
+{
+    m_hoveredTile = -1;
+    update();
+}
+
+// ---------------------------------------------------------------------------
+// TileBrowser
+
+TileBrowser::TileBrowser(QWidget* parent)
+    : QDockWidget("Tile Browser", parent)
+    , m_widget(new TileBrowserWidget())
+    , m_scroll(new QScrollArea())
+{
+    setAllowedAreas(Qt::AllDockWidgetAreas);
+    setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable
+                | QDockWidget::DockWidgetClosable);
+
+    auto* sizeCombo = new QComboBox();
+    sizeCombo->addItem("Small (32px)",  32);
+    sizeCombo->addItem("Medium (64px)", 64);
+    sizeCombo->addItem("Large (96px)",  96);
+    sizeCombo->setCurrentIndex(1);
+
+    m_scroll->setWidget(m_widget);
+    m_scroll->setWidgetResizable(true);
+    m_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+    auto* container = new QWidget();
+    auto* layout    = new QVBoxLayout(container);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(2);
+    layout->addWidget(sizeCombo);
+    layout->addWidget(m_scroll);
+    setWidget(container);
+
+    connect(sizeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, [this, sizeCombo](int) {
+        m_widget->setTileSize(sizeCombo->currentData().toInt());
+    });
+
+    connect(m_widget, &TileBrowserWidget::tileSelected,
+            this,     &TileBrowser::tileSelected);
+    connect(m_widget, &TileBrowserWidget::stampCreated,
+            this,     &TileBrowser::stampCreated);
+}
+
+void TileBrowser::setTileset(const Tileset* ts)
+{
+    m_widget->setTileset(ts);
+}

--- a/src/tilebrowser.h
+++ b/src/tilebrowser.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <QDockWidget>
+#include <QWidget>
+#include <QPixmap>
+#include <QPoint>
+#include <QScrollArea>
+#include "tlsloader.h"
+#include "stamp.h"
+
+class TileBrowserWidget : public QWidget {
+    Q_OBJECT
+public:
+    explicit TileBrowserWidget(QWidget* parent = nullptr);
+
+    void setTileset(const Tileset* ts);
+    void setTileSize(int px);
+    int  tileSize() const { return m_tileSize; }
+
+signals:
+    void tileSelected(int id);
+    void stampCreated(Stamp s);   // emitted when a multi-tile drag-select is released
+
+protected:
+    void paintEvent(QPaintEvent*) override;
+    void mousePressEvent(QMouseEvent*) override;
+    void mouseMoveEvent(QMouseEvent*) override;
+    void mouseReleaseEvent(QMouseEvent*) override;
+    void leaveEvent(QEvent*) override;
+    QSize sizeHint() const override;
+
+private:
+    int    cols() const;
+    QPoint gridPos(QPoint widgetPos) const;   // (col, row) in tile grid
+    int    tileIdAt(QPoint grid) const;       // tile id from grid pos, -1 if OOB
+
+    const Tileset* m_tileset     = nullptr;
+    QPixmap        m_atlasPixmap;
+    static constexpr int ATLAS_COLS = 64;
+    int m_tileSize     = 64;
+    int m_selectedTile = 0;
+    int m_hoveredTile  = -1;
+
+    // Drag selection
+    bool   m_dragging  = false;
+    QPoint m_selStart;   // grid (col, row) where drag began
+    QPoint m_selEnd;     // grid (col, row) at current drag position
+};
+
+class TileBrowser : public QDockWidget {
+    Q_OBJECT
+public:
+    explicit TileBrowser(QWidget* parent = nullptr);
+
+    void setTileset(const Tileset* ts);
+
+signals:
+    void tileSelected(int id);
+    void stampCreated(Stamp s);
+
+private:
+    TileBrowserWidget* m_widget;
+    QScrollArea*       m_scroll;
+};

--- a/src/tilepanel.cpp
+++ b/src/tilepanel.cpp
@@ -18,9 +18,15 @@ TilePanelWidget::TilePanelWidget(QWidget* parent)
 
 int TilePanelWidget::cols() const
 {
-    // Use as many columns as fit into our current width, minimum 1.
     const int available = std::max(width(), RENDER_SIZE);
     return std::max(1, available / RENDER_SIZE);
+}
+
+void TilePanelWidget::setSelectedTile(int id)
+{
+    if (id == m_selectedTile) return;
+    m_selectedTile = id;
+    update();
 }
 
 QSize TilePanelWidget::sizeHint() const
@@ -127,15 +133,15 @@ void TilePanelWidget::mouseMoveEvent(QMouseEvent* ev)
 TilePanel::TilePanel(QWidget* parent)
     : QDockWidget("Tiles", parent)
     , m_widget(new TilePanelWidget())
+    , m_scroll(new QScrollArea())
 {
     setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
     setFeatures(QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
 
-    auto* scroll = new QScrollArea();
-    scroll->setWidget(m_widget);
-    scroll->setWidgetResizable(true);
-    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-    setWidget(scroll);
+    m_scroll->setWidget(m_widget);
+    m_scroll->setWidgetResizable(true);
+    m_scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    setWidget(m_scroll);
 
     connect(m_widget, &TilePanelWidget::tileSelected,
             this,     &TilePanel::tileSelected);
@@ -144,4 +150,16 @@ TilePanel::TilePanel(QWidget* parent)
 void TilePanel::setTileset(const Tileset* ts)
 {
     m_widget->setTileset(ts);
+}
+
+void TilePanel::setSelectedTile(int id)
+{
+    m_widget->setSelectedTile(id);
+    // Scroll so the selected tile is visible
+    const int c   = m_widget->cols();
+    const int col = id % c;
+    const int row = id / c;
+    const int x   = col * TilePanelWidget::RENDER_SIZE;
+    const int y   = row * TilePanelWidget::RENDER_SIZE;
+    m_scroll->ensureVisible(x, y, TilePanelWidget::RENDER_SIZE, TilePanelWidget::RENDER_SIZE);
 }

--- a/src/tilepanel.h
+++ b/src/tilepanel.h
@@ -2,6 +2,7 @@
 #include <QDockWidget>
 #include <QWidget>
 #include <QPixmap>
+#include <QScrollArea>
 #include "tlsloader.h"
 
 // Internal scrollable widget that renders the tile grid.
@@ -16,6 +17,9 @@ public:
     const Tileset* tileset() const { return m_tileset; }
 
     int selectedTile() const { return m_selectedTile; }
+    void setSelectedTile(int id);
+
+    int cols() const;
 
 signals:
     void tileSelected(int id);
@@ -27,7 +31,6 @@ protected:
     QSize sizeHint() const override;
 
 private:
-    int cols() const;
     int tileAt(QPoint pos) const;
 
     const Tileset* m_tileset = nullptr;
@@ -46,6 +49,7 @@ public:
     explicit TilePanel(QWidget* parent = nullptr);
 
     void setTileset(const Tileset* ts);
+    void setSelectedTile(int id);
     TilePanelWidget* panelWidget() const { return m_widget; }
 
 signals:
@@ -53,4 +57,5 @@ signals:
 
 private:
     TilePanelWidget* m_widget;
+    QScrollArea*     m_scroll;
 };

--- a/src/tlsloader.cpp
+++ b/src/tlsloader.cpp
@@ -1,6 +1,8 @@
 #include "tlsloader.h"
 #include "npmformat.h"
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
 #include <algorithm>
 
 bool Tileset::load(const QString& path)
@@ -30,6 +32,25 @@ bool Tileset::load(const QString& path)
     for (int i = 0; i < 256; ++i) {
         const int base = TLS_OFF_PALETTE + i * 3;
         palette[i] = qRgb(buf[base], buf[base + 1], buf[base + 2]);
+    }
+
+    // The game renders tiles using an external netp.act palette, not the
+    // TLS-embedded one. Walk up from the TLS file's directory to find it.
+    {
+        QDir dir = QFileInfo(path).absoluteDir();
+        for (int attempt = 0; attempt < 5; ++attempt) {
+            QFile actFile(dir.filePath("netp.act"));
+            if (actFile.open(QIODevice::ReadOnly)) {
+                const QByteArray actData = actFile.readAll();
+                if (actData.size() >= 768) {
+                    const auto* ab = reinterpret_cast<const unsigned char*>(actData.constData());
+                    for (int i = 0; i < 256; ++i)
+                        palette[i] = qRgb(ab[i*3], ab[i*3+1], ab[i*3+2]);
+                }
+                break;
+            }
+            if (!dir.cdUp()) break;
+        }
     }
 
     // Tile headers immediately after fixed header block

--- a/tests/test_maploader.cpp
+++ b/tests/test_maploader.cpp
@@ -293,6 +293,32 @@ private slots:
     }
 
     // -----------------------------------------------------------------------
+    void testSpnParsing_noNewlines()
+    {
+        // Some real-world .spn files concatenate all tokens on one line.
+        const QString spnText =
+            "SpawnCount: 3Location: 5 10Location: 30 40Location: 99 7";
+        const QString path = writeTempFile(spnText.toUtf8(), ".spn");
+
+        const QString npmPath = path.chopped(4) + ".npm";
+        const QByteArray npm = makeNpm(128, 128, {});
+        QFile nf(npmPath); nf.open(QIODevice::WriteOnly); nf.write(npm);
+
+        const Map loaded = MapLoader::load(npmPath);
+        QVERIFY(loaded.isValid());
+
+        int spawns = 0;
+        for (const auto& obj : loaded.objects)
+            if (obj.type == "spawnpoint") ++spawns;
+        QCOMPARE(spawns, 3);
+
+        QCOMPARE(loaded.objects[0].x, 5);
+        QCOMPARE(loaded.objects[0].y, 10);
+        QCOMPARE(loaded.objects[2].x, 99);
+        QCOMPARE(loaded.objects[2].y, 7);
+    }
+
+    // -----------------------------------------------------------------------
     void testOptWrite_roundTrip()
     {
         Map orig;


### PR DESCRIPTION
The game renders tiles using the global wads/netp.act palette, not the palette embedded in the .tls file. The two differ significantly (only 85 of 256 entries match for summer12mb), causing tiles to appear as visual noise. Now walks up from the .tls file's directory to find netp.act and uses it if present, falling back to the embedded palette otherwise.

Fixes #10

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/7adf62f7-12ab-4950-a2d9-aab17f47a65c" />